### PR TITLE
updating front page to have research areas

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,32 +18,43 @@ layout: default
 
       <section>
         <h2>
-          Welcome to the Radiation Transport and Reactor Physics
-          research group in the School of Nuclear Science and
-          Engineering at Oregon State University
+          Welcome to the Radiation Transport and Reactor Physics research group in
+          the School of Nuclear Science and Engineering at Oregon State University
         </h2>
 
-        <h4>
-          Our PI is <a href="{{ site.url }}users/palmerts/">Dr. Todd Palmer</a>. We
-          mostly live and work in the Radiation Center on the OSU campus. Our current members are:
-        </h4>
 
+        <h4>
+          Our PI is <a href="{{ site.url }}users/palmerts/">Dr. Todd Palmer</a>. We are located in the Radiation Center on the Oregon State campus. Our research group is primarily focused on reactor physics, but we are a rather diverse bunch. 
+        </h4>
+<hr>
+<h2> Research Areas</h2>
+<h4>Radiation Transport</h4>
 <ul>
 <li><a href="{{ site.url }}users/albertia/">Tony Alberti</a> (<a href="https://github.com/albeanth" class="user-mention">@albeanth</a>)</li>
-<li><a href="{{ site.url }}users/colvinem/">Emory Colvin</a> (<a href="https://github.com/colvinem" class="user-mention">@colvinem</a>)</li>
-<li><a href="{{ site.url }}users/combsky/">Kyle Combs</a> (<a href="https://github.com/Yoshimitsu45" class="user-mention">@Yoshimitsu45</a>)</li>
 <li><a href="{{ site.url }}users/harterj/">Jackson Harter</a> (<a href="https://github.com/harterj" class="user-mention">@harterj</a>)</li>
-<li><a href="{{ site.url }}users/grechanp/">Pavel Grachanuk</a> (<a href="https://github.com/grechasneak" class="user-mention">@grechasneak</a>)</li>
 <li><a href="{{ site.url }}users/keppenj/">Jackson Keppen</a> (<a href="https://github.com/keppenj" class="user-mention">@keppenj</a>)</li>
 <li><a href="{{ site.url }}users/lamad/">Adam Lam</a> (<a href="https://github.com/albeanth" class="user-mention">@adam-lam</a>)</li>
-<li><a href="{{ site.url }}users/lilleybe/">Ben Lilley</a> (<a href="https://github.com/albeanth" class="user-mention">@lilleybe</a>)</li>
-<li><a href="{{ site.url }}users/pharnb/">Ben Pharn</a> (<a href="https://github.com/albeanth" class="user-mention">@pharnb</a>)</li>
-<li><a href="{{ site.url }}users/schicklr/">Robert Schickler</a> (<a href="https://github.com/albeanth" class="user-mention">@robertschickler</a>)</li>
-<li><a href="{{ site.url }}users/tamashia/">Aaron Tamashiro</a> (<a href="https://github.com/aarontama" class="user-mention">@aarontama</a>)</li>
 <li><a href="{{ site.url }}users/whitmann/">Nick Whitman</a> (<a href="https://github.com/nickwhitman1993" class="user-mention">@nickwhitman1993</a>)</li>
 <li><a href="{{ site.url }}users/woodsdou/">Doug Woods</a> (<a href="https://github.com/dougwoods3" class="user-mention">@dougwoods3</a>)</li>
 </ul>
 
+<h4>Core Design and Fuel Analysis</h4>
+<ul>
+<li><a href="{{ site.url }}users/colvinem/">Emory Colvin</a> (<a href="https://github.com/colvinem" class="user-mention">@colvinem</a>)</li>
+<li><a href="{{ site.url }}users/grechanp/">Pavel Grachanuk</a> (<a href="https://github.com/grechasneak" class="user-mention">@grechasneak</a>)</li>
+<li><a href="{{ site.url }}users/schicklr/">Robert Schickler</a> (<a href="https://github.com/albeanth" class="user-mention">@robertschickler</a>)</li>
+<li><a href="{{ site.url }}users/tamashia/">Aaron Tamashiro</a> (<a href="https://github.com/aarontama" class="user-mention">@aarontama</a>)</li>
+
+</ul>
+<h4>Safeguards and Security</h4>
+<ul>
+<li><a href="{{ site.url }}users/pharnb/">Ben Pharn</a> (<a href="https://github.com/albeanth" class="user-mention">@pharnb</a>)</li>
+</ul>
+<h4>Uncertainty Quantification</h4>
+<ul>
+<li><a href="{{ site.url }}users/combsky/">Kyle Combs</a> (<a href="https://github.com/Yoshimitsu45" class="user-mention">@Yoshimitsu45</a>)</li>
+<li><a href="{{ site.url }}users/lilleybe/">Ben Lilley</a> (<a href="https://github.com/albeanth" class="user-mention">@lilleybe</a>)</li>
+</ul>
       </section>
       <footer>
         <img src="{{ site.url }}images/osulogo-horizontal.png" alt="Oregon State University">


### PR DESCRIPTION
So things are seperated by research area now...basically, its got a line under the end of "rather diverse bunch", and then does "Research Areas" and has a bulleted list for everyone. I'd love to hear any feedback