### PR TITLE
Fixed RTRP page formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,6 @@ layout: default
 <li><a href="{{ site.url }}users/lamad/">Adam Lam</a> (<a href="https://github.com/adam-lam" class="user-mention">@adam-lam</a>)</li>
 <li><a href="{{ site.url }}users/whitmann/">Nick Whitman</a> (<a href="https://github.com/nickwhitman1993" class="user-mention">@nickwhitman1993</a>)</li>
 <li><a href="{{ site.url }}users/reynolaa/">Aaron J Reynolds</a> (<a href="https://github.com/aaronjamesreynolds" class="user-mention">@aaronjamesreynolds</a>)</li>
-
 </ul>
 
 <h4>Core Design and Fuel Analysis</h4>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@ layout: default
 <li><a href="{{ site.url }}users/schicklr/">Robert Schickler</a> (<a href="https://github.com/robertschickler" class="user-mention">@robertschickler</a>)</li>
 <li><a href="{{ site.url }}users/stewryan/">Ryan Stewart</a> (<a href="https://github.com/ryanstwrt" class="user-mention">@ryanstwrt</a>)</li>
 <li><a href="{{ site.url }}users/hillszach/">Zachary Hills</a> (<a href="https://github.com/zachthills" class="user-mention">@zachthills</a>)</li>
-
+</ul>
 
 <h4>Uncertainty Quantification</h4>
 <ul>


### PR DESCRIPTION
Accidentally deleted a closing statement on the webpage, which caused a bunch of stuff to indent. Went ahead and put it back in. 